### PR TITLE
fix: add getStaticPaths to articles dynamic route

### DIFF
--- a/apps/main-website/src/pages/articles/[slug].astro
+++ b/apps/main-website/src/pages/articles/[slug].astro
@@ -1,5 +1,11 @@
 ---
-import { getArticle } from '../../lib/loadContent.ts';
+import { getArticle, listArticles } from '../../lib/loadContent.ts';
+
+export async function getStaticPaths() {
+  const items = listArticles();
+  return items.map((i) => ({ params: { slug: i.slug } }));
+}
+
 const { slug } = Astro.params;
 const a = getArticle(slug as string);
 if (!a) throw new Error('Not found');


### PR DESCRIPTION
Adds getStaticPaths export for src/pages/articles/[slug].astro so Astro static builds succeed. This uses existing listArticles() from lib/loadContent.ts.